### PR TITLE
Fix empty category model when creating a new category via findCategoryByPath()

### DIFF
--- a/engine/Shopware/Components/Api/Resource/Category.php
+++ b/engine/Shopware/Components/Api/Resource/Category.php
@@ -268,10 +268,10 @@ class Category extends Resource
                     }
                 }
 
-                $categoryModel = new CategoryModel();
-                $this->getManager()->persist($categoryModel);
-                $categoryModel->setParent($parent);
-                $categoryModel->setName($categoryName);
+                $categoryModel = $this->create(array(
+                    'name' => $categoryName,
+                    'parentId' => $parentId
+                ));
             }
 
             $parentId = $categoryModel->getId();


### PR DESCRIPTION
When using `findCategoryByPath()` with parameter `$create = true`, a new category should have been created, but had an empty `id` when querying it a few lines beneath via `$categoryModel->getId()`

When using the built-in `create()` function, everything works as expected.